### PR TITLE
Hide seconds feature, fix pause bug

### DIFF
--- a/mainform1.lfm
+++ b/mainform1.lfm
@@ -1,8 +1,8 @@
 object MainForm: TMainForm
-  Left = 1652
-  Height = 242
-  Top = 436
-  Width = 377
+  Left = 533
+  Height = 363
+  Top = 312
+  Width = 392
   HorzScrollBar.Page = 274
   HorzScrollBar.Range = 275
   HorzScrollBar.Visible = False
@@ -11,10 +11,11 @@ object MainForm: TMainForm
   VertScrollBar.Visible = False
   ActiveControl = Minutes
   Caption = 'SnapTimer'
-  ClientHeight = 222
-  ClientWidth = 377
-  Constraints.MinHeight = 70
-  Constraints.MinWidth = 180
+  ClientHeight = 333
+  ClientWidth = 392
+  Constraints.MinHeight = 105
+  Constraints.MinWidth = 240
+  DesignTimePPI = 144
   KeyPreview = True
   Menu = MainMenu1
   OnActivate = FormActivate
@@ -24,27 +25,28 @@ object MainForm: TMainForm
   OnShow = OnShowForm
   OnWindowStateChange = FormWindowStateChange
   Position = poScreenCenter
-  LCLVersion = '1.2.6.0'
+  LCLVersion = '2.0.10.0'
   object TimeLabel: TLabel
     AnchorSideRight.Control = Minutes
-    Left = 7
-    Height = 16
-    Top = 5
-    Width = 47
+    Left = 10
+    Height = 24
+    Top = 8
+    Width = 70
     AutoSize = False
-    BorderSpacing.Left = 5
-    BorderSpacing.Right = 2
+    BorderSpacing.Left = 8
+    BorderSpacing.Right = 3
     Caption = 'Minutes:'
     FocusControl = Minutes
     Layout = tlCenter
     ParentColor = False
+    ParentFont = False
   end
   object ImgStart: TImage
-    Left = 125
-    Height = 25
+    Left = 168
+    Height = 38
     Hint = 'Start'
-    Top = 1
-    Width = 25
+    Top = 3
+    Width = 38
     OnClick = ToggleCountdown
     ParentShowHint = False
     Picture.Data = {
@@ -108,11 +110,11 @@ object MainForm: TMainForm
     ShowHint = True
   end
   object ImgReset: TImage
-    Left = 155
-    Height = 25
+    Left = 208
+    Height = 38
     Hint = 'Reset'
-    Top = 1
-    Width = 25
+    Top = 3
+    Width = 38
     OnClick = ResetCountdown
     ParentShowHint = False
     Picture.Data = {
@@ -177,11 +179,11 @@ object MainForm: TMainForm
     ShowHint = True
   end
   object ImgPause: TImage
-    Left = 125
-    Height = 25
+    Left = 168
+    Height = 38
     Hint = 'Pause'
-    Top = 1
-    Width = 25
+    Top = 3
+    Width = 38
     OnClick = ToggleCountdown
     ParentShowHint = False
     Picture.Data = {
@@ -250,10 +252,10 @@ object MainForm: TMainForm
     Visible = False
   end
   object ImgIconRunning: TImage
-    Left = 155
-    Height = 15
-    Top = 40
-    Width = 10
+    Left = 232
+    Height = 22
+    Top = 60
+    Width = 15
     Picture.Data = {
       055449636F6E7E04000000000100010010100000010020006804000016000000
       2800000010000000200000000100200000000000000000000000000000000000
@@ -296,10 +298,10 @@ object MainForm: TMainForm
     Visible = False
   end
   object ImgIconPaused: TImage
-    Left = 160
-    Height = 15
-    Top = 40
-    Width = 10
+    Left = 240
+    Height = 22
+    Top = 60
+    Width = 15
     Picture.Data = {
       055449636F6E7E04000000000100010010100000010020006804000016000000
       2800000010000000200000000100200000000000000000000000000000000000
@@ -342,10 +344,10 @@ object MainForm: TMainForm
     Visible = False
   end
   object ImgIconDone: TImage
-    Left = 160
-    Height = 15
-    Top = 40
-    Width = 10
+    Left = 240
+    Height = 22
+    Top = 60
+    Width = 15
     Picture.Data = {
       055449636F6E7E04000000000100010010100000010020006804000016000000
       2800000010000000200000000100200000000000000000000000000000000000
@@ -388,10 +390,10 @@ object MainForm: TMainForm
     Visible = False
   end
   object ImgIconMain: TImage
-    Left = 160
-    Height = 15
-    Top = 40
-    Width = 10
+    Left = 240
+    Height = 22
+    Top = 60
+    Width = 15
     Picture.Data = {
       055449636F6E7E04000000000100010010100000010020006804000016000000
       2800000010000000200000000100200000000000000000000000000000000000
@@ -435,32 +437,33 @@ object MainForm: TMainForm
   end
   object Minutes: TSpinEdit
     AnchorSideLeft.Side = asrBottom
-    Left = 60
-    Height = 23
-    Top = 2
-    Width = 47
-    BorderSpacing.Right = 5
+    Left = 88
+    Height = 33
+    Top = 3
+    Width = 70
+    BorderSpacing.Right = 8
     Increment = 5
     MaxValue = 5999
     OnChange = MinutesChanged
+    ParentFont = False
     TabOrder = 0
   end
   object Count: TStaticText
     Cursor = crHandPoint
-    Left = 2
-    Height = 190
+    Left = 3
+    Height = 301
     Top = 32
-    Width = 373
+    Width = 386
     Align = alBottom
     Alignment = taCenter
     Anchors = [akTop, akLeft, akRight]
-    BorderSpacing.Left = 2
-    BorderSpacing.Top = 4
-    BorderSpacing.Right = 2
+    BorderSpacing.Left = 3
+    BorderSpacing.Top = 6
+    BorderSpacing.Right = 3
     BorderStyle = sbsSunken
     Caption = '00:00:00'
     Font.CharSet = ANSI_CHARSET
-    Font.Height = -48
+    Font.Height = -72
     Font.Name = 'Arial Narrow'
     Font.Pitch = fpVariable
     Font.Quality = fqDraft
@@ -474,8 +477,8 @@ object MainForm: TMainForm
     Enabled = False
     OnTimer = Countdown
     OnStartTimer = Countdown
-    left = 192
-    top = 160
+    Left = 288
+    Top = 240
   end
   object TrayIconMain: TTrayIcon
     BalloonFlags = bfInfo
@@ -521,12 +524,12 @@ object MainForm: TMainForm
     }
     Visible = True
     OnClick = ToggleCountdown
-    left = 112
-    top = 160
+    Left = 168
+    Top = 240
   end
   object MainMenu1: TMainMenu
-    left = 24
-    top = 104
+    Left = 36
+    Top = 156
     object MenuFile: TMenuItem
       Caption = 'File'
       object MenuToggle: TMenuItem
@@ -567,8 +570,8 @@ object MainForm: TMainForm
     end
   end
   object TrayMenu: TPopupMenu
-    left = 24
-    top = 160
+    Left = 36
+    Top = 240
     object MenuCount: TMenuItem
       Caption = 'Countdown'
       Enabled = False
@@ -606,8 +609,8 @@ object MainForm: TMainForm
     end
   end
   object PopupMenuCompact: TPopupMenu
-    left = 128
-    top = 104
+    Left = 192
+    Top = 156
     object MenuCompact: TMenuItem
       Caption = 'Toggle compact mode'
       OnClick = ToggleCompact

--- a/mainform1.pas
+++ b/mainform1.pas
@@ -91,6 +91,7 @@ type
     AlwaysOnTop: boolean;
     MinToTray: boolean;
     AutoStart: boolean;
+    HideSeconds: boolean;
     ClickTime: boolean;
     DblClickTime: boolean;
     AutoRestart: boolean;
@@ -145,6 +146,7 @@ const
   INI_ALWAYS_ON_TOP = 'AlwaysOnTop';
   INI_MIN_TO_TRAY = 'MinToTray';
   INI_AUTOSTART = 'AutoStart';
+  INI_HIDESECONDS = 'HideSeconds';
   INI_CLICKTIME = 'ClickTime';
   INI_DBLCLICKTIME = 'DoubleClickTime';
   INI_AUTORESTART = 'AutoRestart';
@@ -203,6 +205,7 @@ const
   DEF_ALWAYS_ON_TOP = False;
   DEF_MIN_TO_TRAY = False;
   DEF_AUTOSTART = False;
+  DEF_HIDESECONDS = False;
   DEF_CLICKTIME = True;
   DEF_DBLCLICKTIME = True;
   DEF_AUTORESTART = False;
@@ -248,6 +251,7 @@ begin
   AlwaysOnTop := DEF_ALWAYS_ON_TOP;
   MinToTray   := DEF_MIN_TO_TRAY;
   AutoStart   := DEF_AUTOSTART;
+  HideSeconds := DEF_HIDESECONDS;
   ClickTime   := DEF_CLICKTIME;
   DblClickTime := DEF_DBLCLICKTIME;
   AutoRestart := DEF_AUTORESTART;
@@ -304,6 +308,7 @@ begin
     AlwaysOnTop := IniFile.ReadBool(INI_SEC_MAIN, INI_ALWAYS_ON_TOP, DEF_ALWAYS_ON_TOP);
     MinToTray := IniFile.ReadBool(INI_SEC_MAIN, INI_MIN_TO_TRAY, DEF_MIN_TO_TRAY);
     AutoStart := IniFile.ReadBool(INI_SEC_MAIN, INI_AUTOSTART, DEF_AUTOSTART);
+    HideSeconds := IniFile.ReadBool(INI_SEC_MAIN, INI_HIDESECONDS, DEF_HIDESECONDS);
     ClickTime := IniFile.ReadBool(INI_SEC_MAIN, INI_CLICKTIME, DEF_CLICKTIME);
     DblClickTime := IniFile.ReadBool(INI_SEC_MAIN, INI_DBLCLICKTIME, DEF_DBLCLICKTIME);
     AutoRestart := IniFile.ReadBool(INI_SEC_MAIN, INI_AUTORESTART, DEF_AUTORESTART);
@@ -421,6 +426,7 @@ begin
     CheckAlwaysOnTop.Checked  := AlwaysOnTop;
     CheckMinToTray.Checked    := MinToTray;
     CheckAutostart.Checked    := AutoStart;
+    CheckHideSeconds.Checked  := HideSeconds;
     CheckClicktime.Checked    := ClickTime;
     CheckDblClickTime.Checked := DblClickTime;
     CheckAutoRestart.Checked  := AutoRestart;
@@ -458,6 +464,7 @@ begin
       AlwaysOnTop  := CheckAlwaysOnTop.Checked;
       MinToTray    := CheckMinToTray.Checked;
       AutoStart    := CheckAutostart.Checked;
+      HideSeconds  := CheckHideSeconds.Checked;
       ClickTime    := CheckClicktime.Checked;
       DblClickTime := CheckDblClickTime.Checked;
       AutoRestart  := CheckAutoRestart.Checked;
@@ -667,6 +674,7 @@ begin
     IniFile.WriteBool(INI_SEC_MAIN, INI_ALWAYS_ON_TOP, AlwaysOnTop);
     IniFile.WriteBool(INI_SEC_MAIN, INI_MIN_TO_TRAY, MinToTray);
     IniFile.WriteBool(INI_SEC_MAIN, INI_AUTOSTART, AutoStart);
+    IniFile.WriteBool(INI_SEC_MAIN, INI_HIDESECONDS, HideSeconds);
     IniFile.WriteBool(INI_SEC_MAIN, INI_CLICKTIME, ClickTime);
     IniFile.WriteBool(INI_SEC_MAIN, INI_DBLCLICKTIME, DblClickTime);
     IniFile.WriteBool(INI_SEC_MAIN, INI_AUTORESTART, AutoRestart);
@@ -750,7 +758,14 @@ begin
   h      := Seconds div 3600;
   m      := Seconds div 60 - h * 60;
   s      := Seconds - (h * 3600 + m * 60);
-  Result := SysUtils.Format('%.2d:%.2d:%.2d', [h, m, s]);
+  if HideSeconds then
+  begin
+    Result := SysUtils.Format('%.2d:%.2d', [h, m]);
+  end
+  else
+  begin
+    Result := SysUtils.Format('%.2d:%.2d:%.2d', [h, m, s]);
+  end;
 end;
 
 procedure TMainForm.FormKeyPress(Sender: TObject; var Key: char);

--- a/mainform1.pas
+++ b/mainform1.pas
@@ -533,6 +533,7 @@ begin
     DisableTimer();
   end
   else
+  begin
     if CountdownDone then
     begin
         // TODO When restarting after countdown has elapsed, quickly jumps from
@@ -542,6 +543,7 @@ begin
         EndTime := Now + (Timer1.Tag * OneSecond);
     end;
     EnableTimer();
+  end
 end;
 
 procedure TMainForm.Countdown(Sender: TObject);

--- a/settings.lfm
+++ b/settings.lfm
@@ -1,24 +1,25 @@
 object OptionsForm: TOptionsForm
-  Left = 1648
-  Height = 234
-  Top = 619
-  Width = 550
+  Left = 465
+  Height = 351
+  Top = 319
+  Width = 825
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   Caption = 'Options'
-  ClientHeight = 234
-  ClientWidth = 550
+  ClientHeight = 351
+  ClientWidth = 825
+  DesignTimePPI = 144
   KeyPreview = True
   OnCreate = EnableFields
   OnKeyPress = FormKeyPress
   Position = poScreenCenter
   ShowInTaskBar = stNever
-  LCLVersion = '1.2.6.0'
+  LCLVersion = '2.0.10.0'
   object BtnOk: TButton
-    Left = 384
-    Height = 25
-    Top = 200
-    Width = 75
+    Left = 576
+    Height = 38
+    Top = 300
+    Width = 112
     Caption = '&OK'
     Default = True
     ModalResult = 1
@@ -26,10 +27,10 @@ object OptionsForm: TOptionsForm
     TabOrder = 1
   end
   object BtnCancel: TButton
-    Left = 464
-    Height = 25
-    Top = 200
-    Width = 75
+    Left = 696
+    Height = 38
+    Top = 300
+    Width = 112
     Caption = '&Cancel'
     ModalResult = 2
     ParentFont = False
@@ -37,22 +38,24 @@ object OptionsForm: TOptionsForm
   end
   object PageControl1: TPageControl
     Left = 0
-    Height = 192
+    Height = 288
     Top = 0
-    Width = 552
-    ActivePage = FontsTab
-    TabIndex = 2
+    Width = 828
+    ActivePage = GeneralTab
+    ParentFont = False
+    TabIndex = 0
     TabOrder = 0
     object GeneralTab: TTabSheet
       Caption = 'General'
-      ClientHeight = 164
-      ClientWidth = 544
+      ClientHeight = 250
+      ClientWidth = 820
+      ParentFont = False
       object CheckAutostart: TCheckBox
-        Left = 164
-        Height = 19
+        Left = 256
+        Height = 29
         Hint = 'Begin counting down when the application starts'
-        Top = 74
-        Width = 100
+        Top = 111
+        Width = 150
         Caption = '&Autostart timer'
         ParentFont = False
         ParentShowHint = False
@@ -60,11 +63,11 @@ object OptionsForm: TOptionsForm
         TabOrder = 4
       end
       object CheckMinToTray: TCheckBox
-        Left = 12
-        Height = 19
+        Left = 18
+        Height = 29
         Hint = 'Don''t show the application in the taskbar when minimized'
-        Top = 106
-        Width = 106
+        Top = 159
+        Width = 158
         Caption = '&Minimize to tray'
         ParentFont = False
         ParentShowHint = False
@@ -72,22 +75,24 @@ object OptionsForm: TOptionsForm
         TabOrder = 2
       end
       object GroupBox2: TGroupBox
-        Left = 4
-        Height = 48
-        Top = 10
-        Width = 160
+        Left = 6
+        Height = 72
+        Top = 19
+        Width = 240
         Caption = 'Starting position'
-        ClientHeight = 30
-        ClientWidth = 156
+        ClientHeight = 42
+        ClientWidth = 236
+        ParentFont = False
         TabOrder = 0
         object PositionCombo: TComboBox
-          Left = 6
-          Height = 23
+          Left = 9
+          Height = 33
           Hint = 'Where to place the application window when it starts'
-          Top = 2
-          Width = 144
+          Top = 3
+          Width = 216
           DropDownCount = 6
-          ItemHeight = 15
+          ItemHeight = 25
+          ParentFont = False
           ParentShowHint = False
           ShowHint = True
           Style = csDropDownList
@@ -95,111 +100,133 @@ object OptionsForm: TOptionsForm
         end
       end
       object CheckClickTime: TCheckBox
-        Left = 164
-        Height = 19
+        Left = 256
+        Height = 29
         Hint = 'Click the timer numerals to start/pause the timer'
-        Top = 106
-        Width = 113
+        Top = 159
+        Width = 168
         Caption = 'Cl&ick time to start'
+        ParentFont = False
         ParentShowHint = False
         ShowHint = True
         TabOrder = 5
       end
       object CheckDblClickTime: TCheckBox
-        Left = 164
-        Height = 19
+        Left = 256
+        Height = 29
         Hint = 'Double-click the timer numerals to reset the timer'
-        Top = 138
-        Width = 156
+        Top = 207
+        Width = 233
         Caption = '&Double-click time to reset'
+        ParentFont = False
         ParentShowHint = False
         ShowHint = True
         TabOrder = 6
       end
       object CheckAutoRestart: TCheckBox
-        Left = 348
-        Height = 19
+        Left = 522
+        Height = 29
         Hint = 'Start the timer again when the time reaches zero'
-        Top = 74
-        Width = 161
+        Top = 111
+        Width = 239
         Caption = 'Automatically &restart timer'
+        ParentFont = False
         ParentShowHint = False
         ShowHint = True
         TabOrder = 8
       end
       object CheckLoopAudio: TCheckBox
-        Left = 348
-        Height = 19
+        Left = 522
+        Height = 29
         Hint = 'Continue playing the audio file until timer is reset'
-        Top = 106
-        Width = 113
+        Top = 159
+        Width = 170
         Caption = '&Loop audio alarm'
+        ParentFont = False
         ParentShowHint = False
         ShowHint = True
         TabOrder = 9
       end
       object CheckAutoSave: TCheckBox
-        Left = 12
-        Height = 19
+        Left = 18
+        Height = 29
         Hint = 'Automatically save settings to the .ini file on exit'
-        Top = 138
-        Width = 113
+        Top = 207
+        Width = 171
         Caption = 'Auto&save settings'
+        ParentFont = False
         ParentShowHint = False
         ShowHint = True
         TabOrder = 3
       end
       object CheckAlwaysOnTop: TCheckBox
-        Left = 12
-        Height = 19
+        Left = 18
+        Height = 29
         Hint = 'Show the window even when it''s deactivated'
-        Top = 74
-        Width = 95
+        Top = 111
+        Width = 144
         Caption = 'Al&ways on top'
+        ParentFont = False
         ParentShowHint = False
         ShowHint = True
         TabOrder = 1
       end
       object CheckTicking: TCheckBox
-        Left = 348
-        Height = 19
+        Left = 522
+        Height = 29
         Hint = 'Play a ticking sound when timer is running'
-        Top = 136
-        Width = 117
+        Top = 204
+        Width = 174
         Caption = '&Play ticking sound'
+        ParentFont = False
         ParentShowHint = False
         ShowHint = True
         TabOrder = 10
       end
       object CheckSecondsMode: TCheckBox
-        Left = 348
-        Height = 19
+        Left = 522
+        Height = 29
         Hint = 'Enter seconds instead of minutes'
-        Top = 39
-        Width = 135
+        Top = 62
+        Width = 204
         Caption = '&Enable seconds mode'
+        ParentFont = False
         ParentShowHint = False
         ShowHint = True
         TabOrder = 7
+      end
+      object CheckHideSeconds: TCheckBox
+        Left = 256
+        Height = 29
+        Hint = 'Begin counting down when the application starts'
+        Top = 62
+        Width = 137
+        Caption = '&Hide seconds'
+        ParentFont = False
+        ParentShowHint = False
+        ShowHint = True
+        TabOrder = 11
       end
     end
     object AlarmsTab: TTabSheet
       Caption = 'Alarms'
       ClientHeight = 166
       ClientWidth = 544
+      ParentFont = False
       object GroupBox1: TGroupBox
-        Left = 4
-        Height = 144
-        Top = 10
-        Width = 534
+        Left = 6
+        Height = 216
+        Top = 15
+        Width = 801
         Caption = 'Notification actions'
-        ClientHeight = 126
-        ClientWidth = 530
+        ClientHeight = 186
+        ClientWidth = 797
+        ParentFont = False
         TabOrder = 0
         object NotifyRunAppOn: TCheckBox
-          Left = 5
+          Left = 8
           Height = 17
-          Top = 92
+          Top = 138
           Width = 84
           Caption = '&Run program:'
           OnClick = EnableFields
@@ -207,9 +234,9 @@ object OptionsForm: TOptionsForm
           TabOrder = 10
         end
         object NotifyAudioOn: TCheckBox
-          Left = 5
+          Left = 8
           Height = 17
-          Top = 63
+          Top = 94
           Width = 88
           Caption = '&Play wave file:'
           OnClick = EnableFields
@@ -217,9 +244,9 @@ object OptionsForm: TOptionsForm
           TabOrder = 6
         end
         object NotifyTrayMsgOn: TCheckBox
-          Left = 5
+          Left = 8
           Height = 17
-          Top = 32
+          Top = 48
           Width = 104
           Caption = '&Show tray popup:'
           OnClick = EnableFields
@@ -227,9 +254,9 @@ object OptionsForm: TOptionsForm
           TabOrder = 3
         end
         object NotifyMsgOn: TCheckBox
-          Left = 5
+          Left = 8
           Height = 17
-          Top = 3
+          Top = 4
           Width = 101
           Caption = '&Display message:'
           OnClick = EnableFields
@@ -237,193 +264,206 @@ object OptionsForm: TOptionsForm
           TabOrder = 0
         end
         object NotifyTrayMsgTest: TButton
-          Left = 452
-          Height = 25
-          Top = 30
-          Width = 75
+          Left = 678
+          Height = 38
+          Top = 45
+          Width = 112
           Caption = 'Test'
           OnClick = TestTrayMsg
           ParentFont = False
           TabOrder = 5
         end
         object NotifyMsgTest: TButton
-          Left = 452
-          Height = 25
-          Top = 1
-          Width = 75
+          Left = 678
+          Height = 38
+          Top = 2
+          Width = 112
           Caption = 'Test'
           OnClick = TestMessage
           ParentFont = False
           TabOrder = 2
         end
         object NotifyRunTest: TButton
-          Left = 452
-          Height = 25
-          Top = 90
-          Width = 75
+          Left = 678
+          Height = 38
+          Top = 135
+          Width = 112
           Caption = 'Test'
           OnClick = TestRunApp
           ParentFont = False
           TabOrder = 13
         end
         object NotifyAudioTest: TButton
-          Left = 452
-          Height = 25
-          Top = 61
-          Width = 75
+          Left = 678
+          Height = 38
+          Top = 92
+          Width = 112
           Caption = 'Test'
           OnClick = TestAudio
           ParentFont = False
           TabOrder = 9
         end
         object NotifyTrayMsg: TEdit
-          Left = 130
+          Left = 195
           Height = 21
-          Top = 32
-          Width = 315
+          Top = 48
+          Width = 472
+          ParentFont = False
           TabOrder = 4
         end
         object NotifyRunBtn: TButton
-          Left = 372
-          Height = 25
-          Top = 90
-          Width = 75
+          Left = 558
+          Height = 38
+          Top = 135
+          Width = 112
           Caption = 'Browse'
           OnClick = GetAppFile
           ParentFont = False
           TabOrder = 12
         end
         object NotifyRunApp: TEdit
-          Left = 130
+          Left = 195
           Height = 21
-          Top = 92
-          Width = 232
+          Top = 138
+          Width = 348
+          ParentFont = False
           TabOrder = 11
         end
         object NotifyAudioBtn: TButton
-          Left = 372
-          Height = 25
-          Top = 61
-          Width = 75
+          Left = 558
+          Height = 38
+          Top = 92
+          Width = 112
           Caption = 'Browse'
           OnClick = GetAudioFile
           ParentFont = False
           TabOrder = 8
         end
         object NotifyAudio: TEdit
-          Left = 130
+          Left = 195
           Height = 21
-          Top = 63
-          Width = 232
+          Top = 94
+          Width = 348
+          ParentFont = False
           TabOrder = 7
         end
         object NotifyMsg: TEdit
-          Left = 130
+          Left = 195
           Height = 21
-          Top = 3
-          Width = 315
+          Top = 4
+          Width = 472
+          ParentFont = False
           TabOrder = 1
         end
       end
     end
     object FontsTab: TTabSheet
       Caption = 'Font'
-      ClientHeight = 164
-      ClientWidth = 544
+      ClientHeight = 250
+      ClientWidth = 820
       OnShow = UpdateFonts
+      ParentFont = False
       object TimerFontBox: TGroupBox
-        Left = 4
-        Height = 104
-        Top = 10
-        Width = 534
+        Left = 6
+        Height = 156
+        Top = 15
+        Width = 801
         Caption = 'Timer font'
-        ClientHeight = 86
-        ClientWidth = 530
+        ClientHeight = 126
+        ClientWidth = 797
+        ParentFont = False
         TabOrder = 0
         object Label1: TLabel
-          Left = 6
-          Height = 15
-          Top = 6
-          Width = 23
+          Left = 9
+          Height = 25
+          Top = 9
+          Width = 35
           Caption = 'Size:'
           ParentColor = False
+          ParentFont = False
         end
         object FontColor: TColorButton
-          Left = 168
-          Height = 25
-          Top = 1
-          Width = 75
+          Left = 252
+          Height = 38
+          Top = 2
+          Width = 112
           BorderWidth = 2
           ButtonColorSize = 16
           ButtonColor = clBlack
           OnColorChanged = UpdateFontColor
+          ParentFont = False
         end
         object BgColor: TColorButton
-          Left = 362
-          Height = 25
-          Top = 1
-          Width = 75
+          Left = 543
+          Height = 38
+          Top = 2
+          Width = 112
           BorderWidth = 2
           ButtonColorSize = 16
           ButtonColor = clSilver
           OnColorChanged = UpdateFonts
+          ParentFont = False
         end
         object LabelTextColor: TLabel
-          Left = 126
-          Height = 15
-          Top = 6
-          Width = 32
+          Left = 189
+          Height = 25
+          Top = 9
+          Width = 47
           Caption = 'Color:'
           ParentColor = False
+          ParentFont = False
         end
         object LabelTextColor1: TLabel
-          Left = 286
-          Height = 15
-          Top = 6
-          Width = 67
+          Left = 429
+          Height = 25
+          Top = 9
+          Width = 99
           Caption = 'Background:'
           ParentColor = False
+          ParentFont = False
         end
         object FontSize: TSpinEdit
-          Left = 46
-          Height = 23
-          Top = 3
-          Width = 47
+          Left = 69
+          Height = 33
+          Top = 4
+          Width = 70
           MaxValue = 1000
           OnChange = UpdateFontSize
+          ParentFont = False
           TabOrder = 0
         end
         object FontName: TStaticText
-          Left = 94
-          Height = 28
-          Top = 47
-          Width = 66
+          Left = 141
+          Height = 41
+          Top = 70
+          Width = 96
           Alignment = taCenter
           AutoSize = True
-          BorderSpacing.InnerBorder = 3
+          BorderSpacing.InnerBorder = 4
           Caption = '00:00:00'
           Color = clCaptionText
-          Font.Height = -16
+          Font.Height = -24
           ParentFont = False
           ParentColor = False
           TabOrder = 2
         end
         object FontNameBtn: TButton
-          Left = 5
-          Height = 25
-          Top = 48
-          Width = 75
+          Left = 8
+          Height = 38
+          Top = 72
+          Width = 112
           Caption = '&Font...'
           OnClick = ChooseFont
+          ParentFont = False
           TabOrder = 1
         end
       end
       object BtnDefaults: TButton
-        Left = 10
-        Height = 25
+        Left = 15
+        Height = 38
         Hint = 'Reset font to default settings'
-        Top = 134
-        Width = 75
+        Top = 201
+        Width = 112
         Caption = '&Defaults'
         OnClick = SetDefaults
         ParentFont = False

--- a/settings.pas
+++ b/settings.pas
@@ -16,6 +16,7 @@ type
     BtnCancel: TButton;
     BtnDefaults: TButton;
     CheckAutoRestart: TCheckBox;
+    CheckHideSeconds: TCheckBox;
     CheckSecondsMode: TCheckBox;
     CheckAutoSave: TCheckBox;
     CheckAlwaysOnTop: TCheckBox;

--- a/snaptimer.lpi
+++ b/snaptimer.lpi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="9"/>
+    <Version Value="11"/>
     <PathDelim Value="\"/>
     <General>
       <SessionStorage Value="InProjectDir"/>
@@ -54,24 +54,26 @@
           <Other>
             <CompilerMessages>
               <IgnoredMessages idx5057="True"/>
-              <UseMsgFile Value="True"/>
             </CompilerMessages>
-            <CompilerPath Value="$(CompPath)"/>
           </Other>
         </CompilerOptions>
       </Item2>
     </BuildModes>
     <PublishOptions>
       <Version Value="2"/>
-      <IgnoreBinaries Value="False"/>
-      <IncludeFileFilter Value="*.(pas|pp|inc|lfm|lpr|lrs|lpi|lpk|sh|xml)"/>
-      <ExcludeFileFilter Value="*.(bak|ppu|ppw|o|so);*~;backup"/>
     </PublishOptions>
     <RunParams>
       <local>
-        <FormatVersion Value="1"/>
         <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
       </local>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default">
+          <local>
+            <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
+          </local>
+        </Mode0>
+      </Modes>
     </RunParams>
     <RequiredPackages Count="2">
       <Item1>
@@ -86,7 +88,6 @@
       <Unit0>
         <Filename Value="snaptimer.lpr"/>
         <IsPartOfProject Value="True"/>
-        <UnitName Value="snaptimer"/>
       </Unit0>
       <Unit1>
         <Filename Value="mainform1.pas"/>
@@ -110,7 +111,6 @@
         <ComponentName Value="OptionsForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <UnitName Value="settings"/>
       </Unit3>
     </Units>
   </ProjectOptions>
@@ -141,9 +141,7 @@
     <Other>
       <CompilerMessages>
         <IgnoredMessages idx5057="True"/>
-        <UseMsgFile Value="True"/>
       </CompilerMessages>
-      <CompilerPath Value="$(CompPath)"/>
     </Other>
   </CompilerOptions>
   <Debugging>


### PR DESCRIPTION
SnapTimer is an amazing app. I've been using it since forever.

I just added a new feature - hiding the seconds. This keeps distractions low as nothing changes every second. This helps with focus a lot when doing Pomodoro style stuff. The window can be narrower now, so it can fit just the hours and minutes.

There's also a bugfix, see the second commit. Now pausing works as expected.

Best regards!